### PR TITLE
Makefile: Use GNU standard MANDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 INSTALL=install
 PREFIX=/usr
-MANDIR?=/local/man/man1
+MANDIR?=/share/man/man1
 
 TARGET := superkey-launch
 


### PR DESCRIPTION
The [GNU Coding Standards](http://www.gnu.org/prep/standards/html_node/Directory-Variables.html) specify the location of `mandir` as `$(datarootdir)/man`, where `datarootdir` is `$(prefix)/share`.